### PR TITLE
Добавлены preparedRepository

### DIFF
--- a/src/main/java/ru/kampaii/examples/domain/repositorys/AccountsRepositoryPreparedImpl.java
+++ b/src/main/java/ru/kampaii/examples/domain/repositorys/AccountsRepositoryPreparedImpl.java
@@ -1,0 +1,31 @@
+package ru.kampaii.examples.domain.repositorys;
+
+import ru.kampaii.examples.domain.entities.AccountsEntity;
+import ru.kampaii.examples.domain.idGenerators.IdGenerator;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Map;
+
+public class AccountsRepositoryPreparedImpl extends AccountsRepositoryImpl {
+    PreparedStatement statement;
+
+    public AccountsRepositoryPreparedImpl(Connection connection, IdGenerator<Integer> idGenerator) throws SQLException {
+        super(connection, idGenerator);
+        this.statement = connection.prepareStatement("INSERT INTO public.accounts(number, balance, type, user_id) VALUES (?, ?, ?, ?);");
+    }
+
+    @Override
+    public AccountsEntity create(AccountsEntity object) throws SQLException {
+        Integer id = makeNewId();
+        Map<String, Object> data = getData(object);
+        data.put(primaryKey, id);
+        statement.setInt(1, (Integer) data.get(namesOfStrings.get(0)));
+        statement.setFloat(2, (Float) data.get(namesOfStrings.get(1)));
+        statement.setInt(3, (Integer) data.get(namesOfStrings.get(2)));
+        statement.setInt(4, (Integer) data.get(namesOfStrings.get(3)));
+        statement.executeUpdate();
+        return makeT(data);
+    }
+}

--- a/src/main/java/ru/kampaii/examples/domain/repositorys/AccountsRepositoryPreparedImpl.java
+++ b/src/main/java/ru/kampaii/examples/domain/repositorys/AccountsRepositoryPreparedImpl.java
@@ -6,7 +6,6 @@ import ru.kampaii.examples.domain.idGenerators.IdGenerator;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.Map;
 
 public class AccountsRepositoryPreparedImpl extends AccountsRepositoryImpl {
     PreparedStatement statement;
@@ -19,13 +18,11 @@ public class AccountsRepositoryPreparedImpl extends AccountsRepositoryImpl {
     @Override
     public AccountsEntity create(AccountsEntity object) throws SQLException {
         Integer id = makeNewId();
-        Map<String, Object> data = getData(object);
-        data.put(primaryKey, id);
-        statement.setInt(1, (Integer) data.get(namesOfStrings.get(0)));
-        statement.setFloat(2, (Float) data.get(namesOfStrings.get(1)));
-        statement.setInt(3, (Integer) data.get(namesOfStrings.get(2)));
-        statement.setInt(4, (Integer) data.get(namesOfStrings.get(3)));
+        statement.setInt(1, id);
+        statement.setFloat(2, object.getBalance());
+        statement.setInt(3, object.getType());
+        statement.setInt(4, object.getUserId());
         statement.executeUpdate();
-        return makeT(data);
+        return new AccountsEntity(id, object.getBalance(), object.getType(), object.getUserId());
     }
 }

--- a/src/main/java/ru/kampaii/examples/domain/repositorys/Repository.java
+++ b/src/main/java/ru/kampaii/examples/domain/repositorys/Repository.java
@@ -29,7 +29,7 @@ public abstract class Repository<T extends Entity, ID> {
      */
     public T getById(ID id) {
         Map<String, Object> representList = new HashMap<>();
-        ResultSet results = null;
+        ResultSet results;
         try {
             results = executeQuery("SELECT * FROM " + tableName + " WHERE " + primaryKey + "=" + id + ";");
             while (results.next()) {
@@ -53,7 +53,7 @@ public abstract class Repository<T extends Entity, ID> {
      * @param object обьект без заданного id
      * @return результат сохранения с получившимся id
      */
-    public T create(T object) {
+    public T create(T object) throws SQLException {
         ID id = makeNewId();
         Map<String, Object> data = getData(object);
         data.put(primaryKey, id);
@@ -139,8 +139,7 @@ public abstract class Repository<T extends Entity, ID> {
 
     public ResultSet executeQuery(String request) throws SQLException {
         var statement = connection.createStatement();
-        var result = statement.executeQuery(request);
-        return result;
+        return statement.executeQuery(request);
     }
 
     private void execute(String request) throws SQLException {
@@ -148,8 +147,8 @@ public abstract class Repository<T extends Entity, ID> {
         statement.execute(request);
     }
 
-    public List createNamesOfStrings() {
-        List<String> names = new ArrayList();
+    public List<String> createNamesOfStrings() {
+        List<String> names = new ArrayList<>();
         try (var statement = connection.createStatement()) {
             ResultSet results = statement.executeQuery("SELECT * FROM " + tableName);
             ResultSetMetaData metaData = results.getMetaData();
@@ -177,7 +176,7 @@ public abstract class Repository<T extends Entity, ID> {
     }
 
     ID makeNewId() {
-        return (ID) idGenerator.makeNewId();
+        return idGenerator.makeNewId();
     }
 
     abstract Map<String, Object> getData(T object);

--- a/src/main/java/ru/kampaii/examples/domain/repositorys/UsersRepositoryPreparedImpl.java
+++ b/src/main/java/ru/kampaii/examples/domain/repositorys/UsersRepositoryPreparedImpl.java
@@ -22,10 +22,10 @@ public class UsersRepositoryPreparedImpl extends UsersRepositoryImpl {
         Integer id = makeNewId();
         Map<String, Object> data = getData(object);
         data.put(primaryKey, id);
-        statement.setInt(1, (Integer) data.get(namesOfStrings.get(0)));
-        statement.setString(2, (String) data.get(namesOfStrings.get(1)));
-        statement.setFloat(3, (Float) data.get(namesOfStrings.get(2)));
+        statement.setInt(1, id);
+        statement.setString(2, object.getName());
+        statement.setFloat(3, object.getTotalBalance());
         statement.executeUpdate();
-        return makeT(data);
+        return new UsersEntity(id, object.getName(), object.getTotalBalance());
     }
 }

--- a/src/main/java/ru/kampaii/examples/domain/repositorys/UsersRepositoryPreparedImpl.java
+++ b/src/main/java/ru/kampaii/examples/domain/repositorys/UsersRepositoryPreparedImpl.java
@@ -1,0 +1,31 @@
+package ru.kampaii.examples.domain.repositorys;
+
+import ru.kampaii.examples.domain.entities.UsersEntity;
+import ru.kampaii.examples.domain.idGenerators.IdGenerator;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Map;
+
+
+public class UsersRepositoryPreparedImpl extends UsersRepositoryImpl {
+    PreparedStatement statement;
+
+    public UsersRepositoryPreparedImpl(Connection connection, IdGenerator<Integer> idGenerator) throws SQLException {
+        super(connection, idGenerator);
+        this.statement = connection.prepareStatement("INSERT INTO public.users(id, fullname, total_balance) VALUES (?, ?, ?);");
+    }
+
+    @Override
+    public UsersEntity create(UsersEntity object) throws SQLException {
+        Integer id = makeNewId();
+        Map<String, Object> data = getData(object);
+        data.put(primaryKey, id);
+        statement.setInt(1, (Integer) data.get(namesOfStrings.get(0)));
+        statement.setString(2, (String) data.get(namesOfStrings.get(1)));
+        statement.setFloat(3, (Float) data.get(namesOfStrings.get(2)));
+        statement.executeUpdate();
+        return makeT(data);
+    }
+}

--- a/src/test/java/ru/kampaii/examples/domain/repositorys/EntityAndRepositoryImplTest.java
+++ b/src/test/java/ru/kampaii/examples/domain/repositorys/EntityAndRepositoryImplTest.java
@@ -38,7 +38,7 @@ class EntityAndRepositoryImplTest {
 
     // отрабатывает 8 минут у Тимура
     @Test
-    void testInsertsWithIdGenerator() {
+    void testInsertsWithCommonIdGenerator() {
         usersRepository = new UsersRepositoryImpl(connection, new IdGeneratorIntegerImpl(connection, "users", "id", 1));
         accountsRepository = new AccountsRepositoryImpl(connection, new IdGeneratorIntegerImpl(connection, "accounts", "number", 1));
         executeTest(usersRepository, accountsRepository, this::singleThreadCreation);
@@ -46,14 +46,14 @@ class EntityAndRepositoryImplTest {
 
     // отрабатывает 5 минут у Тимура
     @Test
-    void EntityAndRepositoryImpl() {
+    void EntityAndRepositoryWithPooledGeneratorImpl() {
         usersRepository = new UsersRepositoryImpl(connection, new PooledIdGeneratorImpl(connection, "users", "id", 1, 1000));
         accountsRepository = new AccountsRepositoryImpl(connection, new PooledIdGeneratorImpl(connection, "accounts", "number", 1, 1000));
         executeTest(usersRepository, accountsRepository, this::singleThreadCreation);
     }
 
     @Test
-    void EntityAndPreparedRepositoryImpl() {
+    void EntityAndPreparedRepositoryWithPooledGeneratorImpl() {
         try {
             usersRepository = new UsersRepositoryPreparedImpl(connection, new PooledIdGeneratorImpl(connection, "users", "id", 1, 1000));
             accountsRepository = new AccountsRepositoryPreparedImpl(connection, new PooledIdGeneratorImpl(connection, "accounts", "number", 1, 1000));


### PR DESCRIPTION
следующее задание: улучшить работу репозиториев со statement. Делаем новую имплементацию usersRepository и accountsRepository которые будут работать на preparedStatement. логика такая - запросы у тебя предварительно одинаковые, достаточно один раз собрать preparedStatement на уровне репозитория и сохранить его в объекте класса
по результату - еще один тест в наш класс теста, снова замеряем - сравниваем